### PR TITLE
-msign-return-address superseded

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 |`-ftrivial-auto-var-init=zero`   |no|[no](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1010685)|no|no|[no](https://bugs.gentoo.org/913339)|[no](https://bugs.launchpad.net/ubuntu/+source/gcc-12/+bug/1972043)|no|no|?|[2023](https://github.com/chimera-linux/cports/commit/ad898a6b645b11dee989f4504e89577f5395ba24)|[2020](https://cs.android.com/android/_/android/platform/build/soong/+/59759dff24ffddca43a1940ed8615f96ee1e875f)|?|
 |`-mbranch-protection=standard`/`-mbranch-target-enforce`|no|[2023](https://git.dpkg.org/cgit/dpkg/dpkg.git/commit/?id=8f5aca71c1435c9913d5562b8cae68b751dff663)|[2020](https://fedoraproject.org/wiki/Changes/Aarch64_PointerAuthentication)|no|no|[2023](https://launchpad.net/ubuntu/+source/dpkg/1.22.0ubuntu1)|no|no|[2023](https://github.com/openbsd/src/commit/990129f49dcc7205208dec5e29b252be8659896d)|[no](https://github.com/chimera-linux/cports/blob/master/src/cbuild/core/profile.py)|?|?|
 |`-mshstk`                        |no|no|no|no|no|no|no|no|no|no|?|?|
-|`-msign-return-address=[all/non-leaf]`|no|no|superseded|no|no|no|no|no|superseded|superseded|?|?|
+|`-msign-return-address=[all/non-leaf]`|no|superseded|superseded|no|no|superseded|no|no|superseded|superseded|?|?|
 
 Note that:
 - some flags are incompatible between each other

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@
 |`-fstack-protector`              |superseded|superseded|superseded|superseded|superseded|superseded|superseded|superseded|superseded|superseded|[2009](https://source.android.com/docs/security/enhancements/enhancements41)|?|
 |`-ftrivial-auto-var-init=zero`   |no|[no](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1010685)|no|no|[no](https://bugs.gentoo.org/913339)|[no](https://bugs.launchpad.net/ubuntu/+source/gcc-12/+bug/1972043)|no|no|?|[2023](https://github.com/chimera-linux/cports/commit/ad898a6b645b11dee989f4504e89577f5395ba24)|[2020](https://cs.android.com/android/_/android/platform/build/soong/+/59759dff24ffddca43a1940ed8615f96ee1e875f)|?|
 |`-mbranch-protection=standard`/`-mbranch-target-enforce`|no|[2023](https://git.dpkg.org/cgit/dpkg/dpkg.git/commit/?id=8f5aca71c1435c9913d5562b8cae68b751dff663)|[2020](https://fedoraproject.org/wiki/Changes/Aarch64_PointerAuthentication)|no|no|[2023](https://launchpad.net/ubuntu/+source/dpkg/1.22.0ubuntu1)|no|no|[2023](https://github.com/openbsd/src/commit/990129f49dcc7205208dec5e29b252be8659896d)|[no](https://github.com/chimera-linux/cports/blob/master/src/cbuild/core/profile.py)|?|?|
-|`-mshstk`                        |no|no|no|no|no|no|no|no|no|no|?|?|
 |`-msign-return-address=[all/non-leaf]`|no|superseded|superseded|no|no|superseded|no|no|superseded|superseded|?|?|
+|`-mshstk`                        |no|no|no|no|no|no|no|no|no|no|?|?|
 
 Note that:
 - some flags are incompatible between each other


### PR DESCRIPTION
From https://gcc.gnu.org/onlinedocs/gcc-9.1.0/gcc/AArch64-Options.html

> -msign-return-address=scope
>
> Select the function scope on which return address signing will be applied. Permissible values are ‘none’, which disables return address signing, ‘non-leaf’, which enables pointer signing for functions which are not leaf functions, and ‘all’, which enables pointer signing for all functions. The default value is ‘none’. **This option has been deprecated by -mbranch-protection.**